### PR TITLE
multiConnect handle all addresses error, this.debug, port, only when addresses > 1

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -399,10 +399,10 @@ export default class Connection extends EventEmitter {
     }
     else {
       Dns.resolve4(connectOpts.host, (err, addresses) => {
-        if(typeof addresses !== 'undefined' && addresses.length > 0)
+        if(typeof addresses !== 'undefined' && addresses.length > 1)
         {
-          this.multiConnect(addresses, port, (opts) =>{
-            this.socket.connect(opts);
+          this.multiConnect(addresses, connectOpts.port, (opts) => {
+            this.socket.connect(opts || connectOpts);
           });
         }
         else
@@ -425,27 +425,36 @@ export default class Connection extends EventEmitter {
   }
 
   multiConnect(addresses, port, callback) {
-    var foundReachableIP = false;
-    addresses.forEach (function(currentValue, index, array){
+    var calledBack = false;
+    var remainingSockets = new Set();
+
+    addresses.forEach ((currentValue, index, array) => {
       var newSocket = new Socket({});
-      
+      remainingSockets.add(newSocket);
       var options = {
         port: port,
         host: currentValue
       };
-              
+
       newSocket.connect(options);
-      newSocket.on('connect', function(){
-        if (!foundReachableIP) {
-          newSocket.destroy();
-          callback(options); 
-          foundReachableIP = true;
+      newSocket.on('connect', () => {
+        if (!calledBack) {
+          calledBack = true;
+          remainingSockets.forEach(v => { v.destroy(); });
+          remainingSockets.clear();
+          callback(options);
         }
       });
 
-      newSocket.on('error', function(err){
-        this.debug.log("error to connect to ip address " + currentValue);
+      newSocket.on('error', err => {
+        var message = "multiConnect failed to connect to " + currentValue + ":" + port + " - " + err.message;
+        this.debug.log(message);
+        remainingSockets.delete(newSocket);
         newSocket.destroy();
+        if (!calledBack && remainingSockets.size == 0) {
+          calledBack = true;
+          callback(undefined); //error for all addresses 
+        }
       });
     });
   }


### PR DESCRIPTION
a)  In the on-error handler the this.debug will be undefined, from googling it looks like we need a different syntax on the callbacks where we’d like ‘this’ to be accessible, so instead of:
var x = f(function(a,b,c) { …this.debug…});
               we need:
var x = f( (a,b,c) => { …this.debug…});
               .
b)  The multiConnect logic only called when addresses.length > 1 (instead of > 0).

c)  Passing connectOpts.port instead of port to multiConnect to match the logic used to set connectOpts.port.

d)  multiConnect now handles the case when all addresses result in an error – by making sure that callback is called in this scenario (or else a hang) – here I call callback passing undefined so in the caller to multiConnect when undefined is returned then connectOpts is used instead.
